### PR TITLE
feat(TravisCI): add support for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: elixir
+elixir:
+  - 1.2.0
+otp_release:
+  - 18.1
+addons:
+  postgresql: "9.4"
+services:
+  - postgresql

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,8 @@ config :stataz_api, StatazApi.Endpoint,
 config :stataz_api, StatazApi.Repo,
   adapter: Ecto.Adapters.Postgres,
   hostname: "localhost",
+  username: System.get_env("ENV_STATAZAPI_DB_USERNAME") || "postgres",
+  database: System.get_env("ENV_STATAZAPI_DB_DATABASE") || "database",
   pool_size: 10
 
 # Configures Elixir's Logger


### PR DESCRIPTION
Implement travis-ci to automatically run the tests when the github repo
is updated.

The config has been updated to have a default db username and db
database name (which can also be taken from environment variables)
as this will make the travis-ci integration easier.
