### PR TITLE
feat(Status): add status model with CRUD routes

### DIFF
--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -105,5 +105,8 @@ msgstr "Resource can't be found"
 msgid "unauthorized"
 msgstr "Authentication failed"
 
+msgid "forbidden"
+msgstr "Forbidden"
+
 msgid "unprocessable_entity"
 msgstr "Semantic errors"

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -102,5 +102,8 @@ msgstr ""
 msgid "unauthorized"
 msgstr ""
 
+msgid "forbidden"
+msgstr ""
+
 msgid "unprocessable_entity"
 msgstr ""

--- a/priv/repo/migrations/20160110135452_create_status.exs
+++ b/priv/repo/migrations/20160110135452_create_status.exs
@@ -1,0 +1,15 @@
+defmodule StatazApi.Repo.Migrations.CreateStatus do
+  use Ecto.Migration
+
+  def change do
+    create table(:statuses) do
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :description, :string, size: 32
+      add :active, :boolean, default: false
+
+      timestamps
+    end
+
+    create index(:statuses, [:user_id])
+  end
+end

--- a/test/controllers/status_controller_test.exs
+++ b/test/controllers/status_controller_test.exs
@@ -1,0 +1,231 @@
+defmodule StatazApi.StatusControllerTest do
+  use StatazApi.ConnCase
+
+  alias StatazApi.TestCommon
+  alias StatazApi.Status
+
+  @default_user %{username: "luke.skywalker", password: "rebellion", email: "luke@skywalker.com"}
+  @status_1 %{description: "fighting", active: false}
+  @status_2 %{description: "battling", active: true}
+  @status_3 %{description: "training", active: false}
+  @invalid_attrs %{}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  defp authenticate(conn, repo, user_id, expiry_seconds) do
+    token = "tyidirium"
+    TestCommon.build_token(repo, user_id, token, expiry_seconds)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  test "lists all resources for authenticated user", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    status_3 = TestCommon.create_status(Repo, user_luke.id, @status_3.description, @status_3.active)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = get(conn, status_path(conn, :list, user_luke.username))
+
+    expected = [
+                 %{
+                   "id" => status_1.id,
+                   "description" => @status_1.description,
+                   "active" => @status_1.active
+                 },
+                 %{
+                   "id" => status_2.id,
+                   "description" => @status_2.description,
+                   "active" => @status_2.active
+                 },
+                 %{
+                   "id" => status_3.id,
+                   "description" => @status_3.description,
+                   "active" => @status_3.active
+                 }
+               ]
+
+    assert json_response(conn, 200)["data"] == expected
+  end
+
+  test "displays an empty list when no resources exist for authenticated user", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = get(conn, status_path(conn, :list, user_luke.username))
+
+    assert json_response(conn, 200)["data"] == []
+  end
+
+  test "does not list resources when unauthenticated", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    TestCommon.create_status(Repo, user_luke.id, "flying", false)
+
+    conn = get(conn, status_path(conn, :list, user_luke.username))
+    assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, status_path(conn, :create, user_luke.username), @status_1)
+
+    status_1 = Repo.get_by(Status, %{description: @status_1.description})
+
+    assert status_1
+    assert json_response(conn, 201)["data"] == %{"id" => status_1.id,
+                                                "description" => @status_1.description,
+                                                "active" => false
+                                               }
+  end
+
+  test "creates resource and always set active to false", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, status_path(conn, :create, user_luke.username), @status_2)
+
+    status_2 = Repo.get_by(Status, %{description: @status_2.description})
+
+    assert status_2
+    assert json_response(conn, 201)["data"] == %{"id" => status_2.id,
+                                                "description" => @status_2.description,
+                                                "active" => false
+                                               }
+  end
+
+  test "does not create resource and renders errors when data is invald", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, status_path(conn, :create, user_luke.username), @invalid_attrs)
+    assert json_response(conn, 422)["errors"] == %{"description" => ["can't be blank"]}
+  end
+
+  test "does not create resource and renders errors when description is too short", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, status_path(conn, :create, user_luke.username), %{description: "a"})
+    assert json_response(conn, 422)["errors"] == %{"description" => ["should be at least 2 character(s)"]}
+  end
+
+  test "does not create resource and renders errors when description is too long", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, status_path(conn, :create, user_luke.username), %{description: "having a battle in a galaxy, far far away"})
+    assert json_response(conn, 422)["errors"] == %{"description" => ["should be at most 32 character(s)"]}
+  end
+
+  test "updates resource description and renders resource when data is valid", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{description: "dueling"})
+
+    assert json_response(conn, 200)["data"] == %{"id" => status_1.id,
+                                                "description" => "dueling",
+                                                "active" => @status_1.active
+                                               }
+  end
+
+  test "updates active:true resource description and renders resource when data is valid", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = put(conn, status_path(conn, :update, user_luke.username, status_2.id), %{description: "spying"})
+
+    assert json_response(conn, 200)["data"] == %{"id" => status_2.id,
+                                                "description" => "spying",
+                                                "active" => @status_2.active
+                                               }
+  end
+
+  test "updates previous active:true resource to active:false when new active:true resource is set", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+
+    assert status_1.active == false
+    assert status_2.active == true
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{active: true})
+
+    status_2 = Repo.get(Status, status_2.id)
+
+    assert json_response(conn, 200)["data"] == %{"id" => status_1.id,
+                                                "description" => @status_1.description,
+                                                "active" => true
+                                               }
+    assert status_2.active == false
+  end
+
+  test "does not update a resource with active:true to become active:false", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = put(conn, status_path(conn, :update, user_luke.username, status_2.id), %{active: false})
+
+    assert json_response(conn, 403)["errors"]["title"] == "Forbidden"
+  end
+
+  test "does not update description and renders error when the data is invalid", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{description: "a"})
+
+    assert json_response(conn, 422)["errors"] ==  %{"description" => ["should be at least 2 character(s)"]}
+  end
+
+  test "does not update resource when unauthenticated", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+
+    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{description: "dueling"})
+    assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
+  end
+
+  test "does not update resource when non-existent", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = put(conn, status_path(conn, :update, user_luke.username, 1), %{description: "dueling"})
+    assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = delete(conn, status_path(conn, :delete, user_luke.username, status_1.id))
+
+    assert response(conn, 204)
+    refute Repo.get(Status, status_1.id)
+  end
+
+  test "does not delete resource when unauthenticated", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    conn = delete(conn, status_path(conn, :delete, user_luke.username, status_1.id))
+    assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
+  end
+
+  test "does not delete resource when non-existent", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = delete(conn, status_path(conn, :delete, user_luke.username, 1))
+    assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
+  end
+
+  test "does not delete resource when active is true", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = delete(conn, status_path(conn, :delete, user_luke.username, status_2.id))
+
+    assert json_response(conn, 403)["errors"]["title"] == "Forbidden"
+  end
+end

--- a/test/models/status_test.exs
+++ b/test/models/status_test.exs
@@ -1,0 +1,18 @@
+defmodule StatazApi.StatusTest do
+  use StatazApi.ModelCase
+
+  alias StatazApi.Status
+
+  @valid_attrs %{description: "flying", active: false}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Status.changeset(%Status{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Status.changeset(%Status{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/support/test_common.ex
+++ b/test/support/test_common.ex
@@ -11,4 +11,9 @@ defmodule StatazApi.TestCommon do
     StatazApi.User.create_changeset(%StatazApi.User{}, %{username: username, password: password, email: email})
     |> repo.insert!()
   end
+
+  def create_status(repo, user_id, description, active) do
+    StatazApi.Status.changeset(%StatazApi.Status{}, %{user_id: user_id, description: description, active: active})
+    |> repo.insert!()
+  end
 end

--- a/web/controllers/actions/status_create.ex
+++ b/web/controllers/actions/status_create.ex
@@ -1,0 +1,22 @@
+defmodule StatazApi.StatusController.ActionCreate do
+  use StatazApi.Web, :controller
+  alias StatazApi.Status
+
+  def execute(conn, params) do
+    Status.changeset(%Status{}, %{user_id: conn.assigns.current_user.id, description: params["description"]})
+    |> Repo.insert()
+    |> response(conn)
+  end
+
+  defp response({:ok, status}, conn) do
+    conn
+    |> put_status(:created)
+    |> render("show.json", status: status)
+  end
+
+  defp response({:error, changeset}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> render(StatazApi.ChangesetView, "error.json", changeset: changeset)
+  end
+end

--- a/web/controllers/actions/status_delete.ex
+++ b/web/controllers/actions/status_delete.ex
@@ -1,0 +1,25 @@
+defmodule StatazApi.StatusController.ActionDelete do
+  use StatazApi.Web, :controller
+  alias StatazApi.Status
+
+  def execute(conn, %{"id" => id}) do
+    status = Repo.get(Status, id)
+    Status.get_by_id_and_inactive(id)
+    |> Repo.delete_all()
+    |> response(conn, status)
+  end
+
+  defp response({0, _}, conn, nil) do
+    put_status(conn, :not_found)
+    |> render("show.json", error: :not_found)
+  end
+
+  defp response({0, _}, conn, _status) do
+    put_status(conn, :forbidden)
+    |> render("show.json", error: :forbidden)
+  end
+
+  defp response({_rows, _}, conn, _status) do
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/web/controllers/actions/status_list.ex
+++ b/web/controllers/actions/status_list.ex
@@ -1,0 +1,16 @@
+defmodule StatazApi.StatusController.ActionList do
+  use StatazApi.Web, :controller
+  alias StatazApi.Status
+
+  def execute(conn) do
+    Status.get_by_user_id(conn.assigns.current_user.id)
+    |> Repo.all()
+    |> response(conn)
+  end
+
+  defp response(status, conn) do
+    conn
+    |> put_status(:ok)
+    |> render("list.json", status: status)
+  end
+end

--- a/web/controllers/actions/status_update.ex
+++ b/web/controllers/actions/status_update.ex
@@ -1,0 +1,68 @@
+defmodule StatazApi.StatusController.ActionUpdate do
+  use StatazApi.Web, :controller
+  alias StatazApi.Status
+
+  def execute(conn, params) do
+    Repo.get(Status, params["id"])
+    |> check_set_active_true_to_false(params)
+    |> update(conn, params)
+  end
+
+  defp check_set_active_true_to_false(status = %Status{}, params) do
+    if Map.has_key?(params, "active") and active_true_to_false?(%{"active" => status.active}, params) do
+      {:error, :forbidden}
+    else
+      status
+    end
+  end
+
+  defp check_set_active_true_to_false(nil, _params) do
+    {:error, :not_found}
+  end
+
+  defp update({:error, status}, conn, _params) do
+    put_status(conn, status)
+    |> render("show.json", error: status)
+  end
+
+  defp update(status = %Status{}, conn, params) do
+    Status.changeset(status, params)
+    |> Repo.update()
+    |> update_previous_active_true_to_false(params)
+    |> response(conn)
+  end
+
+  defp update_previous_active_true_to_false(status, params) do
+    if active_true?(params) do
+      {:ok, elements} = status
+      Status.update_active_by_user_id_exclude_id(elements.user_id, elements.id)
+      |> Repo.update_all(set: [active: false])
+    end
+    status
+  end
+
+  defp active_true?(params) do
+    Map.has_key?(params, "active") and
+    (
+      params["active"] == true or
+      params["active"] == "true" or
+      params["active"] == "1"
+    )
+  end
+
+  defp active_true_to_false?(params_1, params_2) do
+    active_true?(params_1) and !active_true?(params_2)
+  end
+
+  defp response({:ok, status}, conn) do
+    conn
+    |> put_status(:ok)
+    |> render("show.json", status: status)
+  end
+
+  defp response({:error, changeset}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> render(StatazApi.ChangesetView, "error.json", changeset: changeset)
+  end
+end

--- a/web/controllers/status_controller.ex
+++ b/web/controllers/status_controller.ex
@@ -1,0 +1,24 @@
+defmodule StatazApi.StatusController do
+  use StatazApi.Web, :controller
+
+  alias StatazApi.StatusController.ActionCreate
+  alias StatazApi.StatusController.ActionDelete
+  alias StatazApi.StatusController.ActionUpdate
+  alias StatazApi.StatusController.ActionList
+
+  def create(conn, params) do
+    ActionCreate.execute(conn, params)
+  end
+
+  def delete(conn, params) do
+    ActionDelete.execute(conn, params)
+  end
+
+  def update(conn, params) do
+    ActionUpdate.execute(conn, params)
+  end
+
+  def list(conn, _params) do
+    ActionList.execute(conn)
+  end
+end

--- a/web/models/status.ex
+++ b/web/models/status.ex
@@ -1,0 +1,36 @@
+defmodule StatazApi.Status do
+  use StatazApi.Web, :model
+
+  schema "statuses" do
+    field :description, :string, size: 32
+    field :active, :boolean, default: false
+    belongs_to :user, StatazApi.User
+
+    timestamps
+  end
+
+  @required_fields ~w(description)
+  @optional_fields ~w(active user_id)
+
+  def update_active_by_user_id_exclude_id(user_id, exclude_id) do
+    from s in StatazApi.Status,
+    where: s.user_id == ^user_id and s.id != ^exclude_id
+  end
+
+  def get_by_user_id(user_id) do
+    from s in StatazApi.Status,
+    where: s.user_id == ^user_id
+  end
+
+  def get_by_id_and_inactive(id) do
+    from s in StatazApi.Status,
+    where: s.id == ^id and s.active == false
+  end
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+    |> validate_length(:description, min: 2, max: 32)
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -27,4 +27,14 @@ defmodule StatazApi.Router do
     get "/:username", AuthController, :show
     delete "/:username", AuthController, :delete
   end
+
+  scope "/status", StatazApi do
+    pipe_through :api
+    pipe_through :auth
+
+    get "/:username", StatusController, :list
+    post "/:username", StatusController, :create
+    delete "/:username/:id", StatusController, :delete
+    put "/:username/:id", StatusController, :update
+  end
 end

--- a/web/views/status_view.ex
+++ b/web/views/status_view.ex
@@ -1,0 +1,23 @@
+defmodule StatazApi.StatusView do
+  use StatazApi.Web, :view
+
+  def render("show.json", %{status: status}) do
+    %{data: render_one(status, StatazApi.StatusView, "status.json")}
+  end
+
+  def render("list.json", %{status: status}) do
+    %{data: render_many(status, StatazApi.StatusView, "status.json")}
+  end
+
+  def render("show.json", %{error: error}) do
+    %{errors:
+      %{ title: StatazApi.ErrorHelpers.translate_error(to_string(error)) }
+    }
+  end
+
+  def render("status.json", %{status: status}) do
+    %{id: status.id,
+      description: status.description,
+      active: status.active}
+  end
+end


### PR DESCRIPTION
A Status model has been added that holds the different status
descriptions for a user. It also flags which status is the active one.

There is no `GET / :show` route as it is not relevant to display a single
Status, it is replaced with a `GET / :list` route that displays all of
the user's statuses.

All Status endpoints require authentication before accessing.

It's also worth noting that a Status cannot be created with an active
Status of true as this would cause issues by users accidentally setting
their Status when creating a new one, which is undesireable.

When a Status is updated and it is set to active:true then the previous
active:true Status is automatically set to false, to ensure only one
Status can ever be active:true.

It is also not possible to update the active:true Status to
active:false, which means the only way to set a Status to active:false
is by setting another Status to active:true. This ensures that at least
one Status has to be active:true.

It is also not possible to delete the active:true Status, this means
there must always be at least one Status that is active and means the
user can never be left without a Status.
