### PR TITLE
chore(authentication): remove username from url in authenticated routes

### DIFF
--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -23,7 +23,7 @@ defmodule StatazApi.AuthControllerTest do
 
     assert json_response(conn, 201)["data"]["token_type"] == "bearer"
     assert json_response(conn, 201)["data"]["expires_in"] == 3600
-    assert json_response(conn, 201)["data"]["access_token"] |> String.length == 32
+    assert json_response(conn, 201)["data"]["access_token"] |> String.length == 64
   end
 
   test "does not create resource and returns error when resource not found", %{conn: conn} do
@@ -41,7 +41,7 @@ defmodule StatazApi.AuthControllerTest do
   test "shows chosen resource when authenticated", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = get(conn, auth_path(conn, :show, user_luke.username))
+    conn = get(conn, auth_path(conn, :show))
 
     assert json_response(conn, 200)["data"]["token_type"] == "bearer"
     assert json_response(conn, 200)["data"]["expires_in"] == 3600
@@ -49,15 +49,15 @@ defmodule StatazApi.AuthControllerTest do
   end
 
   test "does not show resource when unauthenticated", %{conn: conn} do
-    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
-    conn = get(conn, auth_path(conn, :show, user_luke.username))
+    TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = get(conn, auth_path(conn, :show))
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
 
   test "does not show resource when token expires", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 0)
-    conn = get(conn, auth_path(conn, :show, user_luke.username))
+    conn = get(conn, auth_path(conn, :show))
 
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
@@ -65,15 +65,15 @@ defmodule StatazApi.AuthControllerTest do
   test "deletes the resource when authenticated", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = delete(conn, auth_path(conn, :delete, user_luke.username))
+    conn = delete(conn, auth_path(conn, :delete))
 
     assert response(conn, 204)
     refute Repo.get_by(AccessToken, user_id: user_luke.id)
   end
 
   test "does not delete resource when unauthenticated", %{conn: conn} do
-    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
-    conn = delete(conn, auth_path(conn, :delete, user_luke.username))
+    TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    conn = delete(conn, auth_path(conn, :delete))
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
 end

--- a/test/controllers/status_controller_test.exs
+++ b/test/controllers/status_controller_test.exs
@@ -28,7 +28,7 @@ defmodule StatazApi.StatusControllerTest do
     status_3 = TestCommon.create_status(Repo, user_luke.id, @status_3.description, @status_3.active)
 
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = get(conn, status_path(conn, :list, user_luke.username))
+    conn = get(conn, status_path(conn, :list))
 
     expected = [
                  %{
@@ -54,7 +54,7 @@ defmodule StatazApi.StatusControllerTest do
   test "displays an empty list when no resources exist for authenticated user", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = get(conn, status_path(conn, :list, user_luke.username))
+    conn = get(conn, status_path(conn, :list))
 
     assert json_response(conn, 200)["data"] == []
   end
@@ -63,14 +63,14 @@ defmodule StatazApi.StatusControllerTest do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     TestCommon.create_status(Repo, user_luke.id, "flying", false)
 
-    conn = get(conn, status_path(conn, :list, user_luke.username))
+    conn = get(conn, status_path(conn, :list))
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
 
   test "creates and renders resource when data is valid", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = post(conn, status_path(conn, :create, user_luke.username), @status_1)
+    conn = post(conn, status_path(conn, :create), @status_1)
 
     status_1 = Repo.get_by(Status, %{description: @status_1.description})
 
@@ -84,7 +84,7 @@ defmodule StatazApi.StatusControllerTest do
   test "creates resource and always set active to false", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = post(conn, status_path(conn, :create, user_luke.username), @status_2)
+    conn = post(conn, status_path(conn, :create), @status_2)
 
     status_2 = Repo.get_by(Status, %{description: @status_2.description})
 
@@ -98,21 +98,21 @@ defmodule StatazApi.StatusControllerTest do
   test "does not create resource and renders errors when data is invald", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = post(conn, status_path(conn, :create, user_luke.username), @invalid_attrs)
+    conn = post(conn, status_path(conn, :create), @invalid_attrs)
     assert json_response(conn, 422)["errors"] == %{"description" => ["can't be blank"]}
   end
 
   test "does not create resource and renders errors when description is too short", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = post(conn, status_path(conn, :create, user_luke.username), %{description: "a"})
+    conn = post(conn, status_path(conn, :create), %{description: "a"})
     assert json_response(conn, 422)["errors"] == %{"description" => ["should be at least 2 character(s)"]}
   end
 
   test "does not create resource and renders errors when description is too long", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = post(conn, status_path(conn, :create, user_luke.username), %{description: "having a battle in a galaxy, far far away"})
+    conn = post(conn, status_path(conn, :create), %{description: "having a battle in a galaxy, far far away"})
     assert json_response(conn, 422)["errors"] == %{"description" => ["should be at most 32 character(s)"]}
   end
 
@@ -121,7 +121,7 @@ defmodule StatazApi.StatusControllerTest do
     status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
 
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{description: "dueling"})
+    conn = put(conn, status_path(conn, :update, status_1.id), %{description: "dueling"})
 
     assert json_response(conn, 200)["data"] == %{"id" => status_1.id,
                                                 "description" => "dueling",
@@ -134,7 +134,7 @@ defmodule StatazApi.StatusControllerTest do
     status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
 
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, status_path(conn, :update, user_luke.username, status_2.id), %{description: "spying"})
+    conn = put(conn, status_path(conn, :update, status_2.id), %{description: "spying"})
 
     assert json_response(conn, 200)["data"] == %{"id" => status_2.id,
                                                 "description" => "spying",
@@ -151,7 +151,7 @@ defmodule StatazApi.StatusControllerTest do
     assert status_2.active == true
 
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{active: true})
+    conn = put(conn, status_path(conn, :update, status_1.id), %{active: true})
 
     status_2 = Repo.get(Status, status_2.id)
 
@@ -166,7 +166,7 @@ defmodule StatazApi.StatusControllerTest do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, status_path(conn, :update, user_luke.username, status_2.id), %{active: false})
+    conn = put(conn, status_path(conn, :update, status_2.id), %{active: false})
 
     assert json_response(conn, 403)["errors"]["title"] == "Forbidden"
   end
@@ -176,7 +176,7 @@ defmodule StatazApi.StatusControllerTest do
     status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
 
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{description: "a"})
+    conn = put(conn, status_path(conn, :update, status_1.id), %{description: "a"})
 
     assert json_response(conn, 422)["errors"] ==  %{"description" => ["should be at least 2 character(s)"]}
   end
@@ -185,14 +185,14 @@ defmodule StatazApi.StatusControllerTest do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
 
-    conn = put(conn, status_path(conn, :update, user_luke.username, status_1.id), %{description: "dueling"})
+    conn = put(conn, status_path(conn, :update, status_1.id), %{description: "dueling"})
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
 
   test "does not update resource when non-existent", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, status_path(conn, :update, user_luke.username, 1), %{description: "dueling"})
+    conn = put(conn, status_path(conn, :update, 1), %{description: "dueling"})
     assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
   end
 
@@ -200,7 +200,7 @@ defmodule StatazApi.StatusControllerTest do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = delete(conn, status_path(conn, :delete, user_luke.username, status_1.id))
+    conn = delete(conn, status_path(conn, :delete, status_1.id))
 
     assert response(conn, 204)
     refute Repo.get(Status, status_1.id)
@@ -209,14 +209,14 @@ defmodule StatazApi.StatusControllerTest do
   test "does not delete resource when unauthenticated", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
-    conn = delete(conn, status_path(conn, :delete, user_luke.username, status_1.id))
+    conn = delete(conn, status_path(conn, :delete, status_1.id))
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
 
   test "does not delete resource when non-existent", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = delete(conn, status_path(conn, :delete, user_luke.username, 1))
+    conn = delete(conn, status_path(conn, :delete, 1))
     assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
   end
 
@@ -224,7 +224,7 @@ defmodule StatazApi.StatusControllerTest do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = delete(conn, status_path(conn, :delete, user_luke.username, status_2.id))
+    conn = delete(conn, status_path(conn, :delete, status_2.id))
 
     assert json_response(conn, 403)["errors"]["title"] == "Forbidden"
   end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -20,22 +20,22 @@ defmodule StatazApi.UserControllerTest do
   test "shows chosen resource", %{conn: conn} do
     user_luke = Repo.insert!(@default_user)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = get(conn, user_path(conn, :show, user_luke.username))
+    conn = get(conn, user_path(conn, :show))
     assert json_response(conn, 200)["data"] == %{"id" => user_luke.id,
                                                  "username" => user_luke.username,
                                                  "email" => user_luke.email}
   end
 
   test "does not show resource when unauthenticated", %{conn: conn} do
-    user_luke = Repo.insert!(@default_user)
-    conn = get(conn, user_path(conn, :show, user_luke.username))
+    Repo.insert!(@default_user)
+    conn = get(conn, user_path(conn, :show))
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
 
   test "does not show resource when token expires", %{conn: conn} do
     user_luke = Repo.insert!(@default_user)
     conn = authenticate(conn, Repo, user_luke.id, 0)
-    conn = get(conn, user_path(conn, :show, user_luke.username))
+    conn = get(conn, user_path(conn, :show))
     assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
   end
 
@@ -47,7 +47,7 @@ defmodule StatazApi.UserControllerTest do
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
     conn = post(conn, user_path(conn, :create), @invalid_attrs)
-    assert json_response(conn, 422)["errors"] != %{}
+    assert json_response(conn, 422)["errors"] == %{"email" => ["can't be blank"], "password" => ["can't be blank"], "username" => ["can't be blank"]}
   end
 
   test "does not create resource and renders errors when username is invalid", %{conn: conn} do
@@ -89,7 +89,7 @@ defmodule StatazApi.UserControllerTest do
 
     update_attrs = %{password: "princess", email: "leia@organa.com"}
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    put(conn, user_path(conn, :update, user_luke.username), update_attrs)
+    put(conn, user_path(conn, :update), update_attrs)
     updated_user = Repo.get_by(User, %{username: "luke.skywalker"})
 
     assert updated_user.password_hash != user_luke.password_hash
@@ -101,7 +101,7 @@ defmodule StatazApi.UserControllerTest do
 
     update_attrs = %{email: "leia@organa.com"}
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    put(conn, user_path(conn, :update, user_luke.username), update_attrs)
+    put(conn, user_path(conn, :update), update_attrs)
     updated_user = Repo.get_by(User, %{username: "luke.skywalker"})
 
     assert updated_user.password_hash == user_luke.password_hash
@@ -113,7 +113,7 @@ defmodule StatazApi.UserControllerTest do
 
     update_attrs = %{password: "princess"}
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    put(conn, user_path(conn, :update, user_luke.username), update_attrs)
+    put(conn, user_path(conn, :update), update_attrs)
     updated_user = Repo.get_by(User, %{username: "luke.skywalker"})
 
     assert updated_user.password_hash != user_luke.password_hash
@@ -126,7 +126,7 @@ defmodule StatazApi.UserControllerTest do
 
     update_attrs = %{password: "smuggler", email: "luke@skywalker.com"}
     conn = authenticate(conn, Repo, user_han.id, 3600)
-    conn = put(conn, user_path(conn, :update, user_han.username), update_attrs)
+    conn = put(conn, user_path(conn, :update), update_attrs)
 
     assert json_response(conn, 422)["errors"] == %{"email" => ["has already been taken"]}
   end
@@ -136,7 +136,7 @@ defmodule StatazApi.UserControllerTest do
 
     update_attrs = %{password: "rebellion", username: "darth.luke"}
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, user_path(conn, :update, user_luke.username), update_attrs)
+    conn = put(conn, user_path(conn, :update), update_attrs)
     assert json_response(conn, 422)["errors"] == %{"username" => ["can't be changed"]}
   end
 
@@ -145,7 +145,7 @@ defmodule StatazApi.UserControllerTest do
 
     update_attrs = %{email: "luke"}
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, user_path(conn, :update, user_luke.username), update_attrs)
+    conn = put(conn, user_path(conn, :update), update_attrs)
     assert json_response(conn, 422)["errors"] == %{"email" => ["has invalid format"]}
   end
 
@@ -154,7 +154,7 @@ defmodule StatazApi.UserControllerTest do
 
     update_attrs = %{password: "rebel"}
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = put(conn, user_path(conn, :update, user_luke.username), update_attrs)
+    conn = put(conn, user_path(conn, :update), update_attrs)
 
     assert json_response(conn, 422)["errors"] == %{"password" => ["should be at least 8 character(s)"]}
   end
@@ -162,7 +162,7 @@ defmodule StatazApi.UserControllerTest do
   test "deletes chosen resource", %{conn: conn} do
     user_luke = Repo.insert!(@default_user)
     conn = authenticate(conn, Repo, user_luke.id, 3600)
-    conn = delete(conn, user_path(conn, :delete, user_luke.username))
+    conn = delete(conn, user_path(conn, :delete))
     assert response(conn, 204)
     refute Repo.get(User, user_luke.id)
   end

--- a/web/controllers/actions/user_create.ex
+++ b/web/controllers/actions/user_create.ex
@@ -11,7 +11,7 @@ defmodule StatazApi.UserController.ActionCreate do
   defp response({:ok, user}, conn) do
     conn
     |> put_status(:created)
-    |> put_resp_header("location", user_path(conn, :show, user.username))
+    |> put_resp_header("location", user_path(conn, :show))
     |> render("show.json", user: user)
   end
 

--- a/web/controllers/actions/user_delete.ex
+++ b/web/controllers/actions/user_delete.ex
@@ -2,8 +2,8 @@ defmodule StatazApi.UserController.ActionDelete do
   use StatazApi.Web, :controller
   alias StatazApi.User
 
-  def execute(conn, username) do
-    Repo.get_by(User, %{username: username})
+  def execute(conn) do
+    Repo.get(User, conn.assigns.current_user.id)
     |> delete(conn)
   end
 

--- a/web/controllers/actions/user_show.ex
+++ b/web/controllers/actions/user_show.ex
@@ -2,8 +2,8 @@ defmodule StatazApi.UserController.ActionShow do
   use StatazApi.Web, :controller
   alias StatazApi.User
 
-  def execute(conn, username) do
-    Repo.get_by(User, %{username: username})
+  def execute(conn) do
+    Repo.get(User, conn.assigns.current_user.id)
     |> response(conn)
   end
 

--- a/web/controllers/actions/user_update.ex
+++ b/web/controllers/actions/user_update.ex
@@ -2,10 +2,9 @@ defmodule StatazApi.UserController.ActionUpdate do
   use StatazApi.Web, :controller
   alias StatazApi.User
 
-  def execute(conn, username) do
-    user_params = conn.body_params
-    Repo.get_by(User, %{username: username})
-    |> update(conn, user_params)
+  def execute(conn, params) do
+    Repo.get(User, conn.assigns.current_user.id)
+    |> update(conn, params)
   end
 
   defp update(user = %User{}, conn, user_params) do

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -10,15 +10,15 @@ defmodule StatazApi.UserController do
     ActionCreate.execute(conn, user_params)
   end
 
-  def show(conn, %{"username" => username}) do
-    ActionShow.execute(conn, username)
+  def show(conn, _params) do
+    ActionShow.execute(conn)
   end
 
-  def update(conn, %{"username" => username}) do
-    ActionUpdate.execute(conn, username)
+  def update(conn, params) do
+    ActionUpdate.execute(conn, params)
   end
 
-  def delete(conn, %{"username" => username}) do
-    ActionDelete.execute(conn, username)
+  def delete(conn, _params) do
+    ActionDelete.execute(conn)
   end
 end

--- a/web/models/access_token.ex
+++ b/web/models/access_token.ex
@@ -13,9 +13,9 @@ defmodule StatazApi.AccessToken do
   @required_fields ~w(token expires)
   @optional_fields ~w(user_id)
 
-  def get_by_user_id_and_token(user_id, token) do
+  def get_by_token(token) do
     from t in StatazApi.AccessToken,
-    where: t.user_id == ^user_id and t.token_hash == ^hash(token)
+    where: t.token_hash == ^hash(token)
   end
 
   def delete_for_user_id_and_token(user_id, token) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -9,14 +9,14 @@ defmodule StatazApi.Router do
     plug StatazApi.Auth, repo: StatazApi.Repo
   end
 
-  scope "/users", StatazApi do
+  scope "/user", StatazApi do
     pipe_through :api
     post "/", UserController, :create
 
     pipe_through :auth
-    get "/:username", UserController, :show
-    delete "/:username", UserController, :delete
-    put "/:username", UserController, :update
+    get "/", UserController, :show
+    delete "/", UserController, :delete
+    put "/", UserController, :update
   end
 
   scope "/auth", StatazApi do
@@ -24,17 +24,17 @@ defmodule StatazApi.Router do
     post "/", AuthController, :create
 
     pipe_through :auth
-    get "/:username", AuthController, :show
-    delete "/:username", AuthController, :delete
+    get "/", AuthController, :show
+    delete "/", AuthController, :delete
   end
 
   scope "/status", StatazApi do
     pipe_through :api
     pipe_through :auth
 
-    get "/:username", StatusController, :list
-    post "/:username", StatusController, :create
-    delete "/:username/:id", StatusController, :delete
-    put "/:username/:id", StatusController, :update
+    get "/", StatusController, :list
+    post "/", StatusController, :create
+    delete "/:id", StatusController, :delete
+    put "/:id", StatusController, :update
   end
 end


### PR DESCRIPTION
Previously, the username was required as a url parameter when calling
any endpoint that needed authentication. This was because the token
lookup also required to know about the username as added protection.

However, it's better to just generate a token using the username as a
seed to prevent potential `access_token` duplication. This means that
the authentication relies only on the `access_token`.

Also, the `/users` route has been renamed to `/user` as it only ever
deals with an indivual user and therefore is confusing using the plural
to identify the resource.
