### PR TITLE
feat(User): require old password on password update

### DIFF
--- a/web/controllers/actions/user_update.ex
+++ b/web/controllers/actions/user_update.ex
@@ -1,21 +1,62 @@
 defmodule StatazApi.UserController.ActionUpdate do
+  import Comeonin.Bcrypt, only: [checkpw: 2]
   use StatazApi.Web, :controller
   alias StatazApi.User
 
   def execute(conn, params) do
-    Repo.get(User, conn.assigns.current_user.id)
-    |> update(conn, params)
+    user = Repo.get(User, conn.assigns.current_user.id)
+
+    Map.delete(params, "password")
+    |> check_password_change(user)
+    |> update(user, conn)
   end
 
-  defp update(user = %User{}, conn, user_params) do
-    User.update_changeset(user, user_params)
+  defp check_password_change(params, user = %User{}) do
+    if Map.get(params, "new_password") && Map.get(params, "old_password") do
+      checkpw(params["old_password"], user.password_hash)
+      |> update_params_password(params)
+    else
+      params
+    end
+  end
+
+  defp check_password_change(params, nil) do
+    params
+  end
+
+  defp update_params_password(true, params) do
+    Map.put(params, "password", params["new_password"])
+  end
+
+  defp update_params_password(false, _params) do
+    {:error, :unauthorized}
+  end
+
+  defp update({:error, status}, _user, conn) do
+    put_status(conn, status)
+    |> render("show.json", error: status)
+  end
+
+  defp update(_params, nil, conn) do
+    put_status(conn, :not_found)
+    |> render("show.json", error: :not_found)
+  end
+
+  defp update(params, user = %User{}, conn) do
+    User.update_changeset(user, params)
+    |> password_changed?(conn)
     |> Repo.update()
     |> response(conn)
   end
 
-  defp update(nil, conn, _user_params) do
-    put_status(conn, :not_found)
-    |> render("show.json", error: :not_found)
+  defp password_changed?(changeset, conn) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{password: _password}} ->
+        StatazApi.Auth.purge_tokens(conn, Repo)
+        changeset
+      _ ->
+        changeset
+    end
   end
 
   defp response({:ok, user}, conn) do

--- a/web/controllers/auth.ex
+++ b/web/controllers/auth.ex
@@ -41,6 +41,13 @@ defmodule StatazApi.Auth do
     conn
   end
 
+  def purge_tokens(conn, repo) do
+    if conn.assigns[:current_user] do
+      AccessToken.get_by_user_id(conn.assigns.current_user.id)
+      |> repo.delete_all()
+    end
+  end
+
   def show_token(conn, repo) do
     access_token = get_req_header(conn, "authorization")
     token = check_token(repo, access_token)
@@ -68,13 +75,13 @@ defmodule StatazApi.Auth do
 
   defp delete_user_token(conn, repo, user_id) do
     access_token = parse_token(get_req_header(conn, "authorization"))
-    AccessToken.delete_for_user_id_and_token(user_id, access_token)
+    AccessToken.get_by_user_id_and_token(user_id, access_token)
     |> repo.delete_all()
   end
 
   defp expire_tokens(repo) do
     Time.ecto_now()
-    |> AccessToken.delete_all_expired()
+    |> AccessToken.get_all_expired()
     |> repo.delete_all()
   end
 

--- a/web/models/access_token.ex
+++ b/web/models/access_token.ex
@@ -18,12 +18,17 @@ defmodule StatazApi.AccessToken do
     where: t.token_hash == ^hash(token)
   end
 
-  def delete_for_user_id_and_token(user_id, token) do
+  def get_by_user_id(user_id) do
+    from t in StatazApi.AccessToken,
+    where: t.user_id == ^user_id
+  end
+
+  def get_by_user_id_and_token(user_id, token) do
     from t in StatazApi.AccessToken,
     where: t.user_id == ^user_id and t.token_hash == ^hash(token)
   end
 
-  def delete_all_expired(datetime) do
+  def get_all_expired(datetime) do
     from t in StatazApi.AccessToken,
     where: t.expires <= ^datetime
   end


### PR DESCRIPTION
Previously, the `PUT /user` route allowed the password to be changed by
simply providing a `password` POST parameter. This meant that the
user's password could be updated by anyone who had a valid
`access_token` meaning it could be easier to compromise a user's
account.

Now, when updating a user's password via the `PUT /user` route along
with a valid `access_token` the existing password must also be provided
in the format of:

```
{
  "old_password": <existing_password>,
  "new_password": <new_password>
}
```

If the `old_password` is invalid then a `401 Unauthorized` will be
returned.

It is no longer possible to pass a `password` parameter via the
`PUT /user` route as it gets stripped from the parameters server side.

Also, when a user's password is successfully changed all previously
created access tokens for that user are deleted ensuring that a new
`access_token` is required using the newly created password.

The queries on the `access_token` model have also been renamed to all
specify `get` in the function name as they are just generic queries and
not related to the action they may perform.
