### PR TITLE
feat(History): add user status history model

### DIFF
--- a/lib/stataz_api/util/time.ex
+++ b/lib/stataz_api/util/time.ex
@@ -23,4 +23,10 @@ defmodule StatazApi.Util.Time do
 
     Date.diff(date1, date2, unit)
   end
+
+  def ecto_datetime_simple_format(date) do
+    {:ok, string} = timex_from_ecto(date)
+                    |> DateFormat.format("%Y-%m-%d %H:%M:%S", :strftime)
+    string
+  end
 end

--- a/priv/repo/migrations/20160112082336_create_history.exs
+++ b/priv/repo/migrations/20160112082336_create_history.exs
@@ -1,0 +1,14 @@
+defmodule StatazApi.Repo.Migrations.CreateHistory do
+  use Ecto.Migration
+
+  def change do
+    create table(:histories) do
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :description, :string, size: 32
+
+      timestamps
+    end
+
+    create index(:histories, [:user_id])
+  end
+end

--- a/test/controllers/profile_controller_test.exs
+++ b/test/controllers/profile_controller_test.exs
@@ -12,6 +12,22 @@ defmodule StatazApi.ProfileControllerTest do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
+  defp authenticate(conn, repo, user_id, expiry_seconds) do
+    token = "tyidirium"
+    TestCommon.build_token(repo, user_id, token, expiry_seconds)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  defp date_to_json(date) do
+    StatazApi.Util.Time.ecto_datetime_simple_format(date)
+  end
+
+  defp get_response_field(conn, index, field) do
+    {:ok, data} = conn.resp_body
+                  |> Poison.decode()
+    Enum.at(data["data"], index)[field]
+  end
+
   test "show resource and render for valid user", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
 
@@ -21,14 +37,62 @@ defmodule StatazApi.ProfileControllerTest do
 
     conn = get(conn, profile_path(conn, :show, user_luke.username))
 
-    {:ok, since} = status_2.updated_at
-                   |> Poison.encode()
-    {:ok, since} = since
-                   |> Poison.decode()
-
-    assert json_response(conn, 200)["data"] == %{"username" => @default_user.username,
+    assert json_response(conn, 200)["data"] == [%{"username" => @default_user.username,
                                                  "status" => @status_2.description,
-                                                 "since" => since}
+                                                 "since" => date_to_json(status_2.updated_at)}]
+  end
+
+  test "show resource and render multiple statuses for each history", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    status_3 = TestCommon.create_status(Repo, user_luke.id, @status_3.description, true)
+
+    conn = get(conn, profile_path(conn, :show, user_luke.username))
+
+    assert json_response(conn, 200)["data"] == [
+                                                 %{"username" => @default_user.username,
+                                                   "status" => @status_3.description,
+                                                   "since" => date_to_json(status_3.updated_at)},
+                                                 %{"username" => @default_user.username,
+                                                   "status" => @status_2.description,
+                                                   "since" => date_to_json(status_2.updated_at)}
+                                               ]
+
+  end
+
+  test "show resource and render multiple statuses limtied to 5 for different history changes via status controller", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    status_3 = TestCommon.create_status(Repo, user_luke.id, @status_3.description, @status_3.active)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    put(conn, status_path(conn, :update, status_1.id), %{active: true})
+    put(conn, status_path(conn, :update, status_3.id), %{active: true})
+    put(conn, status_path(conn, :update, status_2.id), %{active: true})
+    put(conn, status_path(conn, :update, status_1.id), %{active: true})
+    put(conn, status_path(conn, :update, status_3.id), %{active: true})
+
+    conn = get(conn, profile_path(conn, :show, user_luke.username))
+
+    assert json_response(conn, 200)["data"] == [
+                                                 %{"username" => @default_user.username,
+                                                   "status" => @status_3.description,
+                                                   "since" => get_response_field(conn, 4, "since")},
+                                                 %{"username" => @default_user.username,
+                                                   "status" => @status_1.description,
+                                                   "since" => get_response_field(conn, 3, "since")},
+                                                 %{"username" => @default_user.username,
+                                                   "status" => @status_2.description,
+                                                   "since" => get_response_field(conn, 2, "since")},
+                                                 %{"username" => @default_user.username,
+                                                   "status" => @status_3.description,
+                                                   "since" => get_response_field(conn, 1, "since")},
+                                                 %{"username" => @default_user.username,
+                                                   "status" => @status_1.description,
+                                                   "since" => get_response_field(conn, 0, "since")}
+                                               ]
   end
 
   test "does not show resource and renders errors when user not found", %{conn: conn} do

--- a/test/controllers/status_controller_test.exs
+++ b/test/controllers/status_controller_test.exs
@@ -129,6 +129,22 @@ defmodule StatazApi.StatusControllerTest do
                                                }
   end
 
+  test "update resource to active:true adds status to status history", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    status_1 = TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    status_3 = TestCommon.create_status(Repo, user_luke.id, @status_3.description, @status_3.active)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    put(conn, status_path(conn, :update, status_1.id), %{active: true})
+
+    assert Repo.get_by(StatazApi.History, %{description: @status_1.description})
+    refute Repo.get_by(StatazApi.History, %{description: @status_3.description})
+
+    put(conn, status_path(conn, :update, status_3.id), %{active: true})
+
+    assert Repo.get_by(StatazApi.History, %{description: @status_3.description})
+  end
+
   test "updates active:true resource description and renders resource when data is valid", %{conn: conn} do
     user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
     status_2 = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)

--- a/test/models/history_test.exs
+++ b/test/models/history_test.exs
@@ -1,0 +1,18 @@
+defmodule StatazApi.HistoryTest do
+  use StatazApi.ModelCase
+
+  alias StatazApi.History
+
+  @valid_attrs %{description: "flying"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = History.changeset(%History{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = History.changeset(%History{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/support/test_common.ex
+++ b/test/support/test_common.ex
@@ -15,5 +15,17 @@ defmodule StatazApi.TestCommon do
   def create_status(repo, user_id, description, active) do
     StatazApi.Status.changeset(%StatazApi.Status{}, %{user_id: user_id, description: description, active: active})
     |> repo.insert!()
+    |> create_history(repo, user_id)
+  end
+
+  def create_history({:error, changeset}, _repo, _user_id) do
+  end
+
+  def create_history(status = %StatazApi.Status{}, repo, user_id) do
+    if status.active do
+      StatazApi.History.changeset(%StatazApi.History{}, %{user_id: user_id, description: status.description})
+      |> repo.insert!()
+    end
+    status
   end
 end

--- a/web/controllers/actions/status_update.ex
+++ b/web/controllers/actions/status_update.ex
@@ -1,6 +1,7 @@
 defmodule StatazApi.StatusController.ActionUpdate do
   use StatazApi.Web, :controller
   alias StatazApi.Status
+  alias StatazApi.History
 
   def execute(conn, params) do
     Repo.get(Status, params["id"])
@@ -55,6 +56,9 @@ defmodule StatazApi.StatusController.ActionUpdate do
   end
 
   defp response({:ok, status}, conn) do
+    if status.active do
+      add_history(conn.assigns.current_user.id, status.description)
+    end
     conn
     |> put_status(:ok)
     |> render("show.json", status: status)
@@ -64,5 +68,10 @@ defmodule StatazApi.StatusController.ActionUpdate do
     conn
     |> put_status(:unprocessable_entity)
     |> render(StatazApi.ChangesetView, "error.json", changeset: changeset)
+  end
+
+  defp add_history(user_id, description) do
+    History.changeset(%History{}, %{user_id: user_id, description: description})
+    |> Repo.insert()
   end
 end

--- a/web/models/history.ex
+++ b/web/models/history.ex
@@ -1,0 +1,20 @@
+defmodule StatazApi.History do
+  use StatazApi.Web, :model
+
+  schema "histories" do
+    field :description, :string, size: 32
+    belongs_to :user, StatazApi.User
+
+    timestamps
+  end
+
+  @required_fields ~w(description)
+  @optional_fields ~w(user_id)
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+    |> validate_length(:description, min: 2, max: 32)
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/web/models/profile.ex
+++ b/web/models/profile.ex
@@ -2,9 +2,11 @@ defmodule StatazApi.Profile do
   import Ecto.Query, only: [from: 1, from: 2]
 
   def by_user_id(user_id) do
-    from s in StatazApi.Status,
-    join: u in StatazApi.User, on: s.user_id == u.id,
-    where: s.user_id == ^user_id and s.active == true,
+    from h in StatazApi.History,
+    join: u in StatazApi.User, on: h.user_id == u.id,
+    where: h.user_id == ^user_id,
+    order_by: [desc: h.inserted_at, desc: h.id],
+    limit: 5,
     preload: [user: u]
   end
 end

--- a/web/views/profile_view.ex
+++ b/web/views/profile_view.ex
@@ -2,7 +2,7 @@ defmodule StatazApi.ProfileView do
   use StatazApi.Web, :view
 
   def render("show.json", %{profile: profile}) do
-    %{data: render_one(List.first(profile), StatazApi.ProfileView, "profile.json")}
+    %{data: render_many(profile, StatazApi.ProfileView, "profile.json")}
   end
 
   def render("show.json", %{error: error}) do
@@ -14,6 +14,6 @@ defmodule StatazApi.ProfileView do
   def render("profile.json", %{profile: profile}) do
     %{username: profile.user.username,
       status: profile.description,
-      since: profile.updated_at}
+      since: StatazApi.Util.Time.ecto_datetime_simple_format(profile.inserted_at)}
   end
 end


### PR DESCRIPTION
The History model stores every active Status for a User at the point
when the Status is set to active via the `PUT /status/:id` route.

The Profile view now uses these History records to display the current
User Status along with the previous 4 active statuses from History.

This enables the user's profile to contain their current active Status
and a brief record of their previous active statuses.
