### PR TITLE
feat(User): create default status for new user

### DIFF
--- a/priv/gettext/en/LC_MESSAGES/text.po
+++ b/priv/gettext/en/LC_MESSAGES/text.po
@@ -1,0 +1,6 @@
+msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "new"
+msgstr "New"

--- a/priv/gettext/text.pot
+++ b/priv/gettext/text.pot
@@ -1,0 +1,2 @@
+msgid "new"
+msgstr ""

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -42,7 +42,18 @@ defmodule StatazApi.UserControllerTest do
   test "creates and renders resource when data is valid", %{conn: conn} do
     create_attrs = %{username: "han.solo", password: "smuggler", email: "han@solo.com"}
     post(conn, user_path(conn, :create), create_attrs)
-    assert Repo.get_by(User, %{username: "han.solo"})
+    user_han = Repo.get_by(User, %{username: "han.solo"})
+
+    assert user_han
+
+    ## ensure default status is created and active
+    default_status = Repo.get_by(StatazApi.Status, %{user_id: user_han.id})
+
+    assert default_status.description == "New"
+    assert default_status.active == true
+
+    ## ensure the status history is created
+    assert Repo.get_by(StatazApi.History, %{description: "New"})
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do

--- a/web/controllers/actions/status_create.ex
+++ b/web/controllers/actions/status_create.ex
@@ -3,9 +3,13 @@ defmodule StatazApi.StatusController.ActionCreate do
   alias StatazApi.Status
 
   def execute(conn, params) do
-    Status.changeset(%Status{}, %{user_id: conn.assigns.current_user.id, description: params["description"]})
-    |> Repo.insert()
+    build(conn.assigns.current_user.id, params["description"])
     |> response(conn)
+  end
+
+  def build(user_id, description) do
+    Status.changeset(%Status{}, %{user_id: user_id, description: description})
+    |> Repo.insert()
   end
 
   defp response({:ok, status}, conn) do

--- a/web/controllers/actions/user_create.ex
+++ b/web/controllers/actions/user_create.ex
@@ -9,6 +9,7 @@ defmodule StatazApi.UserController.ActionCreate do
   end
 
   defp response({:ok, user}, conn) do
+    seed_default_status(user)
     conn
     |> put_status(:created)
     |> put_resp_header("location", user_path(conn, :show))
@@ -19,5 +20,11 @@ defmodule StatazApi.UserController.ActionCreate do
     conn
     |> put_status(:unprocessable_entity)
     |> render(StatazApi.ChangesetView, "error.json", changeset: changeset)
+  end
+
+  defp seed_default_status(user = %User{}) do
+    default_status = Gettext.dgettext(StatazApi.Gettext, "text", "new")
+    {:ok, status} = StatazApi.StatusController.ActionCreate.build(user.id, default_status)
+    StatazApi.StatusController.ActionUpdate.build(status, %{"active" => true}, user.id)
   end
 end


### PR DESCRIPTION
When a new user is created, a default active status is set to ensure
integrity in the user status data (because a user always needs 1 active
status). As there is a default active status, the user can only create
new statuses and set another one to be active before deleting this
initial status. Therefore, the integrity model of the user always having
at least 1 active status will hold up.
