### PR TITLE
feat(Follow): add follow model with CRD routes

### DIFF
--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -98,6 +98,14 @@ msgid_plural "must be equal to %{count}"
 msgstr[0] ""
 msgstr[1] ""
 
+## From validate_not_changed/2
+msgid "can't be changed"
+msgstr ""
+
+## From follow_self/1
+msgid "can't be the same"
+msgstr ""
+
 ## From HTTP Status Codes
 msgid "not_found"
 msgstr "Resource can't be found"

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -95,6 +95,14 @@ msgid_plural "must be equal to %{count}"
 msgstr[0] ""
 msgstr[1] ""
 
+## From validate_not_changed/2
+msgid "can't be changed"
+msgstr ""
+
+## From follow_self/1
+msgid "can't be the same"
+msgstr ""
+
 ## From HTTP Status Codes
 msgid "not_found"
 msgstr ""

--- a/priv/repo/migrations/20160113100707_create_follow.exs
+++ b/priv/repo/migrations/20160113100707_create_follow.exs
@@ -1,0 +1,15 @@
+defmodule StatazApi.Repo.Migrations.CreateFollow do
+  use Ecto.Migration
+
+  def change do
+    create table(:follows) do
+      add :follower_id, references(:users, on_delete: :delete_all)
+      add :following_id, references(:users, on_delete: :delete_all)
+
+      timestamps
+    end
+
+    create index(:follows, [:follower_id])
+    create index(:follows, [:following_id])
+  end
+end

--- a/test/controllers/follow_controller_test.exs
+++ b/test/controllers/follow_controller_test.exs
@@ -1,0 +1,247 @@
+defmodule StatazApi.FollowControllerTest do
+  use StatazApi.ConnCase
+
+  alias StatazApi.TestCommon
+  alias StatazApi.Follow
+
+  @user_luke %{username: "luke.skywalker", password: "rebellion", email: "luke@skywalker.com", status: "dueling"}
+  @user_han %{username: "han.solo", password: "scoundrel", email: "han@solo.com", status: "smuggling"}
+  @user_leia %{username: "leia.organa", password: "princess", email: "leia@organa.com", status: "debating"}
+  @user_r2d2 %{username: "r2.d2", password: "astrodroid", email: "r2@d2.com", status: "hacking"}
+  @user_c3po %{username: "c.3po", password: "protocoldroid", email: "c@3po.com", status: "interpreting"}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  defp authenticate(conn, repo, user_id, expiry_seconds) do
+    token = "tyidirium"
+    TestCommon.build_token(repo, user_id, token, expiry_seconds)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  test "creates resource for valid follow request", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, follow_path(conn, :create, @user_han.username))
+
+    assert json_response(conn, 201)["data"] == ""
+    assert Repo.get_by(Follow, %{follower_id: user_luke.id, following_id: user_han.id})
+  end
+
+  test "does not create resource and renders errors when unauthenticated", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+
+    conn = post(conn, follow_path(conn, :create, @user_han.username))
+
+    assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
+    refute Repo.get_by(Follow, %{follower_id: user_luke.id, following_id: user_han.id})
+  end
+
+  test "does not create resource and renders errors when already following user", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+
+    TestCommon.create_follow(user_luke.id, user_han.id, Repo)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, follow_path(conn, :create, @user_han.username))
+
+    assert json_response(conn, 403)["errors"]["title"] == "Forbidden"
+  end
+
+  test "does not create resource and renders errors when attempt to follow self", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, follow_path(conn, :create, @user_luke.username))
+
+    assert json_response(conn, 422)["errors"] == %{"following_id" => ["can't be the same"]}
+    refute Repo.get_by(Follow, %{follower_id: user_luke.id, following_id: user_luke.id})
+  end
+
+  test "does not create resource and renders errors when other user is non-existent", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = post(conn, follow_path(conn, :create, @user_han.username))
+
+    assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+
+    TestCommon.create_follow(user_luke.id, user_han.id, Repo)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = delete(conn, follow_path(conn, :delete, @user_han.username))
+
+    assert response(conn, 204)
+    refute Repo.get_by(Follow, %{follower_id: user_luke.id, following_id: user_han.id})
+  end
+
+  test "does not delete resource if unauthenticated", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+
+    TestCommon.create_follow(user_luke.id, user_han.id, Repo)
+
+    conn = delete(conn, follow_path(conn, :delete, @user_han.username))
+
+    assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
+    assert Repo.get_by(Follow, %{follower_id: user_luke.id, following_id: user_han.id})
+  end
+
+  test "does not delete resource if not following", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = delete(conn, follow_path(conn, :delete, @user_han.username))
+
+    assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
+  end
+
+  test "does not delete resource when other user is non-existent", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = delete(conn, follow_path(conn, :delete, @user_han.username))
+
+    assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
+  end
+
+  test "shows authenticated user's follower/following list", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+    user_leia = TestCommon.create_user(Repo, @user_leia.username, @user_leia.password, @user_leia.email)
+    user_r2d2 = TestCommon.create_user(Repo, @user_r2d2.username, @user_r2d2.password, @user_r2d2.email)
+    user_c3po = TestCommon.create_user(Repo, @user_c3po.username, @user_c3po.password, @user_c3po.email)
+
+    TestCommon.create_status(Repo, user_luke.id, @user_luke.status, true)
+    TestCommon.create_status(Repo, user_han.id, @user_han.status, true)
+    TestCommon.create_status(Repo, user_leia.id, @user_leia.status, true)
+    TestCommon.create_status(Repo, user_r2d2.id, @user_r2d2.status, true)
+    TestCommon.create_status(Repo, user_c3po.id, @user_c3po.status, true)
+
+    luke_follows_han = TestCommon.create_follow(user_luke.id, user_han.id, Repo)
+    luke_follows_leia = TestCommon.create_follow(user_luke.id, user_leia.id, Repo)
+    han_follows_luke = TestCommon.create_follow(user_han.id, user_luke.id, Repo)
+    r2d2_follows_luke = TestCommon.create_follow(user_r2d2.id, user_luke.id, Repo)
+    c3po_follows_luke = TestCommon.create_follow(user_c3po.id, user_luke.id, Repo)
+
+    conn = authenticate(conn, Repo, user_luke.id, 3600)
+    conn = get(conn, follow_path(conn, :show))
+
+    expected =  %{
+                  "following" =>
+                    [
+                      %{"username" => @user_leia.username,
+                        "since" => TestCommon.date_to_json(luke_follows_leia.inserted_at),
+                        "status" => @user_leia.status
+                      },
+                      %{"username" => @user_han.username,
+                        "since" => TestCommon.date_to_json(luke_follows_han.inserted_at),
+                        "status" => @user_han.status
+                      }
+                    ],
+                  "followers" =>
+                    [
+                      %{"username" => @user_c3po.username,
+                        "since" => TestCommon.date_to_json(c3po_follows_luke.inserted_at),
+                        "status" => @user_c3po.status
+                      },
+                      %{"username" => @user_r2d2.username,
+                        "since" => TestCommon.date_to_json(r2d2_follows_luke.inserted_at),
+                        "status" => @user_r2d2.status
+                      },
+                      %{"username" => @user_han.username,
+                        "since" => TestCommon.date_to_json(han_follows_luke.inserted_at),
+                        "status" => @user_han.status
+                      }
+                    ]
+                }
+
+    assert json_response(conn, 200)["data"] == expected
+  end
+
+  test "does now show user's follower/following list if not authenticated", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+    user_leia = TestCommon.create_user(Repo, @user_leia.username, @user_leia.password, @user_leia.email)
+    user_r2d2 = TestCommon.create_user(Repo, @user_r2d2.username, @user_r2d2.password, @user_r2d2.email)
+    user_c3po = TestCommon.create_user(Repo, @user_c3po.username, @user_c3po.password, @user_c3po.email)
+
+    TestCommon.create_follow(user_luke.id, user_han.id, Repo)
+    TestCommon.create_follow(user_luke.id, user_leia.id, Repo)
+    TestCommon.create_follow(user_han.id, user_luke.id, Repo)
+    TestCommon.create_follow(user_r2d2.id, user_luke.id, Repo)
+    TestCommon.create_follow(user_c3po.id, user_luke.id, Repo)
+
+    conn = get(conn, follow_path(conn, :show))
+    assert json_response(conn, 401)["errors"]["title"] == "Authentication failed"
+  end
+
+  test "shows public follower/following list without authentication requirement", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @user_luke.username, @user_luke.password, @user_luke.email)
+    user_han = TestCommon.create_user(Repo, @user_han.username, @user_han.password, @user_han.email)
+    user_leia = TestCommon.create_user(Repo, @user_leia.username, @user_leia.password, @user_leia.email)
+    user_r2d2 = TestCommon.create_user(Repo, @user_r2d2.username, @user_r2d2.password, @user_r2d2.email)
+    user_c3po = TestCommon.create_user(Repo, @user_c3po.username, @user_c3po.password, @user_c3po.email)
+
+    TestCommon.create_status(Repo, user_luke.id, @user_luke.status, true)
+    TestCommon.create_status(Repo, user_han.id, @user_han.status, true)
+    TestCommon.create_status(Repo, user_leia.id, @user_leia.status, true)
+    TestCommon.create_status(Repo, user_r2d2.id, @user_r2d2.status, true)
+    TestCommon.create_status(Repo, user_c3po.id, @user_c3po.status, true)
+
+    luke_follows_han = TestCommon.create_follow(user_luke.id, user_han.id, Repo)
+    luke_follows_leia = TestCommon.create_follow(user_luke.id, user_leia.id, Repo)
+    han_follows_luke = TestCommon.create_follow(user_han.id, user_luke.id, Repo)
+    r2d2_follows_luke = TestCommon.create_follow(user_r2d2.id, user_luke.id, Repo)
+    c3po_follows_luke = TestCommon.create_follow(user_c3po.id, user_luke.id, Repo)
+
+    conn = get(conn, follow_path(conn, :public_show, @user_luke.username))
+
+    expected =  %{
+                  "following" =>
+                    [
+                      %{"username" => @user_leia.username,
+                        "since" => TestCommon.date_to_json(luke_follows_leia.inserted_at),
+                        "status" => @user_leia.status
+                      },
+                      %{"username" => @user_han.username,
+                        "since" => TestCommon.date_to_json(luke_follows_han.inserted_at),
+                        "status" => @user_han.status
+                      }
+                    ],
+                  "followers" =>
+                    [
+                      %{"username" => @user_c3po.username,
+                        "since" => TestCommon.date_to_json(c3po_follows_luke.inserted_at),
+                        "status" => @user_c3po.status
+                      },
+                      %{"username" => @user_r2d2.username,
+                        "since" => TestCommon.date_to_json(r2d2_follows_luke.inserted_at),
+                        "status" => @user_r2d2.status
+                      },
+                      %{"username" => @user_han.username,
+                        "since" => TestCommon.date_to_json(han_follows_luke.inserted_at),
+                        "status" => @user_han.status
+                      }
+                    ]
+                }
+
+    assert json_response(conn, 200)["data"] == expected
+  end
+
+  test "does not show public follower/following list for non-existent user", %{conn: conn} do
+    conn = get(conn, follow_path(conn, :public_show, "darth.maul"))
+    assert json_response(conn, 404)["errors"]["title"] == "Resource can't be found"
+  end
+end

--- a/test/controllers/profile_controller_test.exs
+++ b/test/controllers/profile_controller_test.exs
@@ -18,10 +18,6 @@ defmodule StatazApi.ProfileControllerTest do
     put_req_header(conn, "authorization", "Bearer #{token}")
   end
 
-  defp date_to_json(date) do
-    StatazApi.Util.Time.ecto_datetime_simple_format(date)
-  end
-
   defp get_response_field(conn, index, field) do
     {:ok, data} = conn.resp_body
                   |> Poison.decode()
@@ -39,7 +35,7 @@ defmodule StatazApi.ProfileControllerTest do
 
     assert json_response(conn, 200)["data"] == [%{"username" => @default_user.username,
                                                  "status" => @status_2.description,
-                                                 "since" => date_to_json(status_2.updated_at)}]
+                                                 "since" => TestCommon.date_to_json(status_2.updated_at)}]
   end
 
   test "show resource and render multiple statuses for each history", %{conn: conn} do
@@ -53,10 +49,10 @@ defmodule StatazApi.ProfileControllerTest do
     assert json_response(conn, 200)["data"] == [
                                                  %{"username" => @default_user.username,
                                                    "status" => @status_3.description,
-                                                   "since" => date_to_json(status_3.updated_at)},
+                                                   "since" => TestCommon.date_to_json(status_3.updated_at)},
                                                  %{"username" => @default_user.username,
                                                    "status" => @status_2.description,
-                                                   "since" => date_to_json(status_2.updated_at)}
+                                                   "since" => TestCommon.date_to_json(status_2.updated_at)}
                                                ]
 
   end

--- a/test/models/follow_test.exs
+++ b/test/models/follow_test.exs
@@ -1,0 +1,23 @@
+defmodule StatazApi.FollowTest do
+  use StatazApi.ModelCase
+
+  alias StatazApi.Follow
+
+  @valid_attrs %{follower_id: "1", following_id: "2"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Follow.changeset(%Follow{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Follow.changeset(%Follow{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+
+  test "changeset with invalid attributes follower_id same as following_id" do
+    changeset = Follow.changeset(%Follow{}, %{follower_id: "1", following_id: "1"})
+    refute changeset.valid?
+  end
+end

--- a/test/support/test_common.ex
+++ b/test/support/test_common.ex
@@ -18,7 +18,7 @@ defmodule StatazApi.TestCommon do
     |> create_history(repo, user_id)
   end
 
-  def create_history({:error, changeset}, _repo, _user_id) do
+  def create_history({:error, _changeset}, _repo, _user_id) do
   end
 
   def create_history(status = %StatazApi.Status{}, repo, user_id) do
@@ -27,5 +27,14 @@ defmodule StatazApi.TestCommon do
       |> repo.insert!()
     end
     status
+  end
+
+  def create_follow(follower_id, following_id, repo) do
+    StatazApi.Follow.changeset(%StatazApi.Follow{}, %{follower_id: follower_id, following_id: following_id})
+    |> repo.insert!()
+  end
+
+  def date_to_json(date) do
+    StatazApi.Util.Time.ecto_datetime_simple_format(date)
   end
 end

--- a/web/controllers/actions/follow_create.ex
+++ b/web/controllers/actions/follow_create.ex
@@ -1,0 +1,55 @@
+defmodule StatazApi.FollowController.ActionCreate do
+  use StatazApi.Web, :controller
+  alias StatazApi.Follow
+
+  def execute(conn, %{"username" => username}) do
+    Repo.get_by(StatazApi.User, %{username: username})
+    |> create(conn.assigns.current_user)
+    |> response(conn)
+  end
+
+  def execute(conn, _params) do
+    {:error, :http, :unprocessable_entity}
+    |> response(conn)
+  end
+
+  defp create(following_user = %StatazApi.User{}, follower_user) do
+    if not_following?(follower_user.id, following_user.id) do
+      Follow.changeset(%Follow{}, %{follower_id: follower_user.id, following_id: following_user.id})
+      |> Repo.insert()
+    else
+      {:error, :http, :forbidden}
+    end
+  end
+
+  defp create(nil, _follower_user) do
+    {:error, :http, :not_found}
+  end
+
+  defp not_following?(follower_id, following_id) do
+    case Follow.by_follower_id_and_following_id(follower_id, following_id) |> Repo.all() do
+      [] ->
+        true
+      _ ->
+        false
+    end
+  end
+
+  defp response({:ok, follow}, conn) do
+    conn
+    |> put_status(:created)
+    |> render("show.json", follow: follow)
+  end
+
+  defp response({:error, changeset}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> render(StatazApi.ChangesetView, "error.json", changeset: changeset)
+  end
+
+  defp response({:error, :http, error}, conn) do
+    conn
+    |> put_status(error)
+    |> render("show.json", error: error)
+  end
+end

--- a/web/controllers/actions/follow_delete.ex
+++ b/web/controllers/actions/follow_delete.ex
@@ -1,0 +1,38 @@
+defmodule StatazApi.FollowController.ActionDelete do
+  use StatazApi.Web, :controller
+  alias StatazApi.Follow
+
+  def execute(conn, %{"username" => username}) do
+    Repo.get_by(StatazApi.User, %{username: username})
+    |> delete(conn.assigns.current_user)
+    |> response(conn)
+  end
+
+  def execute(conn, _params) do
+    put_status(conn, :unprocessable_entity)
+    |> render("show.json", error: :unprocessable_entity)
+  end
+
+  defp delete(following_user = %StatazApi.User{}, follower_user) do
+    Follow.by_follower_id_and_following_id(follower_user.id, following_user.id)
+    |> Repo.delete_all()
+  end
+
+  defp delete(nil, _follower_user) do
+    {:error, :not_found}
+  end
+
+  defp response({:error, error}, conn) do
+    put_status(conn, error)
+    |> render("show.json", error: error)
+  end
+
+  defp response({0, _}, conn) do
+    put_status(conn, :not_found)
+    |> render("show.json", error: :not_found)
+  end
+
+  defp response({_rows, _}, conn) do
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/web/controllers/actions/follow_show.ex
+++ b/web/controllers/actions/follow_show.ex
@@ -1,0 +1,34 @@
+defmodule StatazApi.FollowController.ActionShow do
+  use StatazApi.Web, :controller
+  alias StatazApi.Follow
+
+  def execute(conn, %{"username" => username}) do
+    Repo.get_by(StatazApi.User, %{username: username})
+    |> show(conn)
+  end
+
+  def execute(conn, _params) do
+    show(conn.assigns.current_user, conn)
+  end
+
+  defp show(nil, conn) do
+    conn
+    |> put_status(:not_found)
+    |> render("show.json", error: :not_found)
+  end
+
+  defp show(user = %StatazApi.User{}, conn) do
+    followers = Follow.by_type_id(:following_id, :follower_id, user.id)
+                |> Repo.all()
+    following = Follow.by_type_id(:follower_id, :following_id, user.id)
+                |> Repo.all()
+
+    response(conn, followers, following)
+  end
+
+  defp response(conn, followers, following) do
+    conn
+    |> put_status(:ok)
+    |> render("show.json", payload: %{followers: followers, following: following})
+  end
+end

--- a/web/controllers/follow_controller.ex
+++ b/web/controllers/follow_controller.ex
@@ -1,0 +1,23 @@
+defmodule StatazApi.FollowController do
+  use StatazApi.Web, :controller
+
+  alias StatazApi.FollowController.ActionCreate
+  alias StatazApi.FollowController.ActionDelete
+  alias StatazApi.FollowController.ActionShow
+
+  def create(conn, params) do
+    ActionCreate.execute(conn, params)
+  end
+
+  def delete(conn, params) do
+    ActionDelete.execute(conn, params)
+  end
+
+  def show(conn, params) do
+    ActionShow.execute(conn, params)
+  end
+
+  def public_show(conn, params) do
+    ActionShow.execute(conn, params)
+  end
+end

--- a/web/models/follow.ex
+++ b/web/models/follow.ex
@@ -1,0 +1,47 @@
+defmodule StatazApi.Follow do
+  use StatazApi.Web, :model
+
+  schema "follows" do
+    belongs_to :follower, StatazApi.User, foreign_key: :follower_id
+    belongs_to :following, StatazApi.User, foreign_key: :following_id
+
+    timestamps
+  end
+
+  @required_fields ~w(follower_id following_id)
+
+  def by_follower_id_and_following_id(follower_id, following_id) do
+    from f in StatazApi.Follow,
+    where: f.follower_id == ^follower_id and f.following_id == ^following_id
+  end
+
+  def by_type_id(your_type, their_type, user_id) do
+    from f in StatazApi.Follow,
+    join: u in StatazApi.User, on: field(f, ^their_type) == u.id,
+    join: s in StatazApi.Status, on: u.id == s.user_id and s.active == true,
+    where: field(f, ^your_type) == ^user_id,
+    order_by: [desc: f.inserted_at, desc: f.id],
+    select: {u.username, f.inserted_at, s.description}
+  end
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, [])
+    |> foreign_key_constraint(:follower_id)
+    |> foreign_key_constraint(:following_id)
+    |> follow_self?()
+  end
+
+  defp follow_self?(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true} ->
+        if get_change(changeset, :follower_id) == get_change(changeset, :following_id) do
+          add_error(changeset, :following_id, "can't be the same")
+        else
+          changeset
+        end
+      _ ->
+        changeset
+    end
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -43,4 +43,16 @@ defmodule StatazApi.Router do
 
     get "/:username", ProfileController, :show
   end
+
+  scope "/follow", StatazApi do
+    pipe_through :api
+
+    get "/:username", FollowController, :public_show
+
+    pipe_through :auth
+
+    get "/", FollowController, :show
+    post "/:username", FollowController, :create
+    delete "/:username", FollowController, :delete
+  end
 end

--- a/web/views/follow_view.ex
+++ b/web/views/follow_view.ex
@@ -1,0 +1,30 @@
+defmodule StatazApi.FollowView do
+  use StatazApi.Web, :view
+
+  def render("show.json", %{follow: _follow}) do
+    %{data: ""}
+  end
+
+  def render("show.json", %{error: error}) do
+    %{errors:
+      %{ title: StatazApi.ErrorHelpers.translate_error(to_string(error)) }
+    }
+  end
+
+  def render("follow.json", %{follow: follow}) do
+    {username, inserted_at, status} = follow
+    %{username: username,
+      since: StatazApi.Util.Time.ecto_datetime_simple_format(inserted_at),
+      status: status}
+  end
+
+  def render("show.json", %{payload: payload}) do
+    %{data:
+      %{
+        followers: render_many(payload.followers, StatazApi.FollowView, "follow.json"),
+        following: render_many(payload.following, StatazApi.FollowView, "follow.json")
+      }
+    }
+  end
+
+end


### PR DESCRIPTION
A Follow model has been added that allows a User to Follow another user
and this relation then determines a user's follower/following list.

The follower/following list can be viewed for the current authenticated
user by calling `GET /follow` and this will always return the user's
follower/following list.

The follower/following list can be viewed for any other user on an
unauthenticated route at `GET /follow/:username` however in the future
this route may return an error if/when user access restrictions are
implemented.
