### PR TITLE
feat(cors): enable cross domain requests from any domain

### DIFF
--- a/lib/stataz_api/endpoint.ex
+++ b/lib/stataz_api/endpoint.ex
@@ -21,6 +21,7 @@ defmodule StatazApi.Endpoint do
 
   plug Plug.RequestId
   plug Plug.Logger
+  plug Corsica, origins: "*", allow_headers: ["accept", "content-type", "authorization"]
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,8 @@ defmodule StatazApi.Mixfile do
      {:gettext, "~> 0.9"},
      {:cowboy, "~> 1.0"},
      {:comeonin, "~> 2.0"},
-     {:timex, "~> 1.0"}]
+     {:timex, "~> 1.0"},
+     {:corsica, "~> 0.4.0"}]
   end
 
   # Aliases are shortcut or tasks specific to the current project.

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "combine": {:hex, :combine, "0.7.0"},
   "comeonin": {:hex, :comeonin, "2.0.0"},
   "connection": {:hex, :connection, "1.0.2"},
+  "corsica": {:hex, :corsica, "0.4.0"},
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
   "decimal": {:hex, :decimal, "1.1.1"},


### PR DESCRIPTION
As the service is potentially accessible from any other domain Corsica
has been added to enable cross domain requests. At the moment it is just
set as a wildcard to allow any domain access, this may change in the
future but for now this is acceptable.
