### PR TITLE
feat(Search): add ability to list statues by user or status

### DIFF
--- a/test/controllers/search_controller_test.exs
+++ b/test/controllers/search_controller_test.exs
@@ -1,0 +1,174 @@
+defmodule StatazApi.SearchControllerTest do
+  use StatazApi.ConnCase
+
+  alias StatazApi.TestCommon
+
+  @default_user %{username: "luke_skywalker", password: "rebellion", email: "luke@skywalker.com"}
+  @status_1 %{description: "fighting", active: false}
+  @status_2 %{description: "battling", active: true}
+  @status_3 %{description: "training", active: false}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all status results when queried by status name", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    user_han = TestCommon.create_user(Repo, "han_solo", "smuggler", "han@solo.com")
+    user_leia = TestCommon.create_user(Repo, "leia_organa", "princess", "pricess@leia.com")
+    user_vader = TestCommon.create_user(Repo, "darth_vader", "darksith", "darth@vader.com")
+
+    TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    TestCommon.create_status(Repo, user_luke.id, @status_3.description, @status_3.active)
+    TestCommon.create_status(Repo, user_han.id, @status_1.description, @status_1.active)
+    TestCommon.create_status(Repo, user_leia.id, @status_3.description, @status_3.active)
+
+    luke_active_status = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    han_active_status = TestCommon.create_status(Repo, user_han.id, @status_2.description, @status_2.active)
+    leia_active_status = TestCommon.create_status(Repo, user_leia.id, @status_2.description, @status_2.active)
+    vader_active_status = TestCommon.create_status(Repo, user_vader.id, @status_2.description, @status_2.active)
+
+    conn = get(conn, search_path(conn, :list_status, @status_2.description))
+
+    expected = [
+                 %{
+                   "since" => TestCommon.date_to_json(vader_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_vader.username
+                 },
+                 %{
+                   "since" => TestCommon.date_to_json(leia_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_leia.username
+                 },
+                 %{
+                   "since" => TestCommon.date_to_json(han_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_han.username
+                 },
+                 %{
+                   "since" => TestCommon.date_to_json(luke_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_luke.username
+                 }
+               ]
+
+    assert json_response(conn, 200)["data"] == expected
+  end
+
+  test "list all status results when queried by username or email", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    user_han = TestCommon.create_user(Repo, "han_solo", "smuggler", "han@solo.com")
+    user_leia = TestCommon.create_user(Repo, "leia_organa", "princess", "pricess@leia.com")
+    user_vader = TestCommon.create_user(Repo, "darth_vader", "darksith", "darth@vader.com")
+    user_anakin = TestCommon.create_user(Repo, "anakin_skywalker", "chosenone", "anakin@skywalker.com")
+
+    # Shmi remarried and surname changed to Lars, but she never updated her email address!
+    # Shmi should still show up in the search results
+
+    user_shmi = TestCommon.create_user(Repo, "shmi_lars", "slavemother", "shmi@skywalker.com")
+
+    TestCommon.create_status(Repo, user_han.id, @status_2.description, @status_2.active)
+    TestCommon.create_status(Repo, user_leia.id, @status_2.description, @status_2.active)
+    TestCommon.create_status(Repo, user_vader.id, @status_2.description, @status_2.active)
+
+    luke_active_status = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    anakin_active_status = TestCommon.create_status(Repo, user_anakin.id, @status_2.description, @status_2.active)
+    shmi_active_status = TestCommon.create_status(Repo, user_shmi.id, @status_2.description, @status_2.active)
+
+    conn = get(conn, search_path(conn, :list_user, "skywalker"))
+
+    expected = [
+                 %{
+                   "since" => TestCommon.date_to_json(shmi_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_shmi.username
+                 },
+                 %{
+                   "since" => TestCommon.date_to_json(anakin_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_anakin.username
+                 },
+                 %{
+                   "since" => TestCommon.date_to_json(luke_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_luke.username
+                 }
+               ]
+
+    assert json_response(conn, 200)["data"] == expected
+  end
+
+  test "lists subset of status results when queried by status name given limit/offset", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    user_han = TestCommon.create_user(Repo, "han_solo", "smuggler", "han@solo.com")
+    user_leia = TestCommon.create_user(Repo, "leia_organa", "princess", "pricess@leia.com")
+    user_vader = TestCommon.create_user(Repo, "darth_vader", "darksith", "darth@vader.com")
+
+    TestCommon.create_status(Repo, user_luke.id, @status_1.description, @status_1.active)
+    TestCommon.create_status(Repo, user_luke.id, @status_3.description, @status_3.active)
+    TestCommon.create_status(Repo, user_han.id, @status_1.description, @status_1.active)
+    TestCommon.create_status(Repo, user_leia.id, @status_3.description, @status_3.active)
+
+    TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    han_active_status = TestCommon.create_status(Repo, user_han.id, @status_2.description, @status_2.active)
+    leia_active_status = TestCommon.create_status(Repo, user_leia.id, @status_2.description, @status_2.active)
+    TestCommon.create_status(Repo, user_vader.id, @status_2.description, @status_2.active)
+
+    conn = get(conn, search_path(conn, :list_status, @status_2.description, limit: 2, offset: 1))
+
+    expected = [
+                 %{
+                   "since" => TestCommon.date_to_json(leia_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_leia.username
+                 },
+                 %{
+                   "since" => TestCommon.date_to_json(han_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_han.username
+                 }
+               ]
+
+    assert json_response(conn, 200)["data"] == expected
+  end
+
+  test "list subset of status results when queried by username or email with given limit/offset", %{conn: conn} do
+    user_luke = TestCommon.create_user(Repo, @default_user.username, @default_user.password, @default_user.email)
+    user_han = TestCommon.create_user(Repo, "han_solo", "smuggler", "han@solo.com")
+    user_leia = TestCommon.create_user(Repo, "leia_organa", "princess", "pricess@leia.com")
+    user_vader = TestCommon.create_user(Repo, "darth_vader", "darksith", "darth@vader.com")
+    user_anakin = TestCommon.create_user(Repo, "anakin_skywalker", "chosenone", "anakin@skywalker.com")
+
+    # Shmi remarried and surname changed to Lars, but she never updated her email address!
+    # Shmi should still show up in the search results
+
+    user_shmi = TestCommon.create_user(Repo, "shmi_lars", "slavemother", "shmi@skywalker.com")
+
+    TestCommon.create_status(Repo, user_han.id, @status_2.description, @status_2.active)
+    TestCommon.create_status(Repo, user_leia.id, @status_2.description, @status_2.active)
+    TestCommon.create_status(Repo, user_vader.id, @status_2.description, @status_2.active)
+
+    luke_active_status = TestCommon.create_status(Repo, user_luke.id, @status_2.description, @status_2.active)
+    anakin_active_status = TestCommon.create_status(Repo, user_anakin.id, @status_2.description, @status_2.active)
+    TestCommon.create_status(Repo, user_shmi.id, @status_2.description, @status_2.active)
+
+    conn = get(conn, search_path(conn, :list_user, "skywalker", limit: 2, offset: 1))
+
+    expected = [
+                 %{
+                   "since" => TestCommon.date_to_json(anakin_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_anakin.username
+                 },
+                 %{
+                   "since" => TestCommon.date_to_json(luke_active_status.updated_at),
+                   "status" => @status_2.description,
+                   "username" => user_luke.username
+                 }
+               ]
+
+    assert json_response(conn, 200)["data"] == expected
+  end
+
+end

--- a/web/controllers/actions/search_show.ex
+++ b/web/controllers/actions/search_show.ex
@@ -1,0 +1,28 @@
+defmodule StatazApi.SearchController.ActionShow do
+  use StatazApi.Web, :controller
+
+  defp get_value(data, default) do
+    if data, do: data, else: default
+  end
+
+  def execute(conn, params, type) do
+    limit = get_value(params["limit"], 10)
+    offset = get_value(params["offset"], 0)
+
+    StatazApi.Status.list_by(type, params["query"], limit, offset)
+    |> Repo.all()
+    |> response(conn)
+  end
+
+  defp response(nil, conn) do
+    conn
+    |> put_status(:not_found)
+    |> render(StatazApi.StatusView, "show.json", error: :not_found)
+  end
+
+  defp response(results, conn) do
+    conn
+    |> put_status(:ok)
+    |> render(StatazApi.StatusView, "show.json", profile: results)
+  end
+end

--- a/web/controllers/search_controller.ex
+++ b/web/controllers/search_controller.ex
@@ -1,0 +1,13 @@
+defmodule StatazApi.SearchController do
+  use StatazApi.Web, :controller
+
+  alias StatazApi.SearchController.ActionShow
+
+  def list_user(conn, params) do
+    ActionShow.execute(conn, params, :user)
+  end
+
+  def list_status(conn, params) do
+    ActionShow.execute(conn, params, :status)
+  end
+end

--- a/web/models/status.ex
+++ b/web/models/status.ex
@@ -35,6 +35,27 @@ defmodule StatazApi.Status do
     preload: [:user]
   end
 
+  def list_by(type, query, limit \\ 10, offset \\ 0)
+
+  def list_by(:status, query, limit, offset) do
+    from h in StatazApi.History,
+    where: ilike(h.description, ^("%#{query}%")),
+    order_by: [desc: h.inserted_at, desc: h.id],
+    limit: ^limit,
+    offset: ^offset,
+    preload: [:user]
+  end
+
+  def list_by(:user, query, limit, offset) do
+    from h in StatazApi.History,
+    join: u in StatazApi.User, on: u.id == h.user_id,
+    where: ilike(u.username, ^("%#{query}%")) or ilike(u.email, ^("%#{query}%")),
+    order_by: [desc: h.inserted_at, desc: h.id],
+    limit: ^limit,
+    offset: ^offset,
+    preload: [:user]
+  end
+
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)

--- a/web/router.ex
+++ b/web/router.ex
@@ -52,4 +52,11 @@ defmodule StatazApi.Router do
     post "/:username", FollowController, :create
     delete "/:username", FollowController, :delete
   end
+
+  scope "/search", StatazApi do
+    pipe_through :api
+
+    get "/user/:query", SearchController, :list_user
+    get "/status/:query", SearchController, :list_status
+  end
 end


### PR DESCRIPTION
It is now possible to receive a list of statuses that match a given
status query or list users by user details and their current status.

`search/status/:query`

Will perform a status search for the given query and return all users
with an active status that is like the given query.

`search/user/:query`

Will perform a user search for the given query and return all users and
their current active status for any user that is like the given query.

Optional query string parameters can be provided to add pagination to
the search results:

`search/user/:query?limit=10&offset=5`

Will perform a search and limit the results to 10 records starting at
record 5.
